### PR TITLE
Use POST for envSave

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,12 @@ mkdir -p dist
 cp index.html dist/index.html
 wrangler pages deploy dist --project-name agentcode
 ```
+
+## Manual testing
+
+To confirm that `.env` persistence works:
+
+1. Deploy the worker and open the app.
+2. Connect to a repository.
+3. Enter some content in the `.env` box and click **Save .env**.
+4. Verify in the network panel that the request to `/api/env` uses the `POST` method and returns a successful response.

--- a/dist/index.html
+++ b/dist/index.html
@@ -614,7 +614,7 @@
       try{
         const slug = state.owner + "/" + state.repo;
         const res = await fetch(apiPath("/api/env"), {
-          method: "PUT",
+          method: "POST",
           headers: headersJSON(),
           body: JSON.stringify({ repo: slug, content: byId("envBox").value || "" })
         });


### PR DESCRIPTION
## Summary
- switch .env save requests from PUT to POST
- document manual .env save verification steps

## Testing
- `npm test`
- `npm run build` *(fails: Missing script "build")*

------
https://chatgpt.com/codex/tasks/task_e_689d9230526c832189a09a78e938c4f2