### PR TITLE
feat: make API base configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,28 @@ cp index.html dist/index.html
 wrangler pages deploy dist --project-name agentcode
 ```
 
+## Configuring API base
+
+The app looks for an API base URL in the following order and falls back to
+relative paths when nothing is provided:
+
+1. `window.API_BASE` global variable.
+2. `<meta name="api-base" content="https://api.example.com">` tag.
+3. `API_BASE` environment variable at build time.
+
+To point the frontend at a different API deployment, define one of the above
+before loading `index.html`. For example:
+
+```html
+<meta name="api-base" content="https://botpad-api.example.workers.dev">
+```
+
+or
+
+```html
+<script>window.API_BASE = "https://botpad-api.example.workers.dev";</script>
+```
+
 ## Manual testing
 
 To confirm that `.env` persistence works:
@@ -23,3 +45,4 @@ To confirm that `.env` persistence works:
 2. Connect to a repository.
 3. Enter some content in the `.env` box and click **Save .env**.
 4. Verify in the network panel that the request to `/api/env` uses the `POST` method and returns a successful response.
+

--- a/dist/index.html
+++ b/dist/index.html
@@ -370,10 +370,16 @@
 
   <script>
     // ---------- Config ----------
-    // If you deploy the API as a separate Worker, set API_BASE to that origin.
-    // On Cloudflare Pages Functions with _worker.js, leave it as "".
+    // API base may be defined via window.API_BASE, a meta tag, or environment variable.
+    // When unspecified, requests fall back to relative paths.
+    function resolveApiBase(){
+      return window.API_BASE
+        || document.querySelector('meta[name="api-base"]')?.getAttribute('content')
+        || (typeof process !== 'undefined' && process.env && process.env.API_BASE)
+        || "";
+    }
     const CONFIG = {
-      API_BASE: "https://botpad-api.whitakerdavid.workers.dev" // example: "https://botpad-api.your.workers.dev"
+      API_BASE: resolveApiBase()
     };
 
     // ---------- Utilities ----------

--- a/index.html
+++ b/index.html
@@ -93,11 +93,18 @@
       <div class="footer">
         <input id="message" class="commit" type="text" placeholder="Commit message, for example: Update">
         <button id="saveAs" class="btn">Save As</button>
-      </div>
-    </div>
   </div>
+  </div>
+</div>
 <script>
-const API_BASE = "https://botpad-api.whitakerdavid.workers.dev";
+// Determine the API base from window, meta tag, or environment variable.
+function getApiBase(){
+  return window.API_BASE
+    || document.querySelector('meta[name="api-base"]')?.getAttribute('content')
+    || (typeof process !== 'undefined' && process.env && process.env.API_BASE)
+    || "";
+}
+const API_BASE = getApiBase();
 const $ = sel => document.querySelector(sel);
 const $$ = sel => Array.from(document.querySelectorAll(sel));
 const state = { repo:"", branch:"", files:[], mode:"app", token:"", currentPath:"", currentSha:"" };


### PR DESCRIPTION
## Summary
- allow API base override via global variable, meta tag, or environment variable
- document API base configuration for alternate deployments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d93d2f17083219312671cb5eedbd0