### PR TITLE
chore: set API base for pages frontend

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>AgentCode BotPad</title>
   <meta name="description" content="Agent friendly code editor with GitHub App or PAT auth, plus .env storage.">
+  <meta name="api-base" content="https://botpad-api.whitakerdev.workers.dev">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'><rect width='256' height='256' fill='%23000'/><text x='50%' y='54%' font-size='120' text-anchor='middle' fill='%23fff' font-family='Courier New, monospace'>AC</text></svg>">
   <!-- CodeMirror 5 -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.css">

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>BotPad - Minimal GitHub Editor</title>
+  <meta name="api-base" content="https://botpad-api.whitakerdev.workers.dev">
   <style>
     :root {
       --bg: #0c0f12;


### PR DESCRIPTION
## Summary
- configure Pages frontend to call botpad API via meta tag

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d9a60796c832184aa9d018412a95c