### PR TITLE
feat: make API base configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ or
 <script>window.API_BASE = "https://botpad-api.example.workers.dev";</script>
 ```
 
+or set an environment variable during build/deploy:
+
+```bash
+API_BASE=https://botpad-api.example.workers.dev wrangler pages deploy dist
+```
+
 ## Manual testing
 
 To confirm that `.env` persistence works:

--- a/dist/index.html
+++ b/dist/index.html
@@ -5,7 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>AgentCode BotPad</title>
   <meta name="description" content="Agent friendly code editor with GitHub App or PAT auth, plus .env storage.">
-  <meta name="api-base" content="https://botpad-api.whitakerdev.workers.dev">
+  <!-- Optional API base override -->
+  <!-- <meta name="api-base" content="https://api.example.com"> -->
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'><rect width='256' height='256' fill='%23000'/><text x='50%' y='54%' font-size='120' text-anchor='middle' fill='%23fff' font-family='Courier New, monospace'>AC</text></svg>">
   <!-- CodeMirror 5 -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.css">

--- a/index.html
+++ b/index.html
@@ -4,7 +4,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>BotPad - Minimal GitHub Editor</title>
-  <meta name="api-base" content="https://botpad-api.whitakerdev.workers.dev">
+  <!-- Optional API base override -->
+  <!-- <meta name="api-base" content="https://api.example.com"> -->
   <style>
     :root {
       --bg: #0c0f12;
@@ -98,7 +99,8 @@
   </div>
 </div>
 <script>
-// Determine the API base from window, meta tag, or environment variable.
+// Determine the API base from window, meta tag, or environment variable,
+// falling back to relative paths when none is provided.
 function getApiBase(){
   return window.API_BASE
     || document.querySelector('meta[name="api-base"]')?.getAttribute('content')


### PR DESCRIPTION
## Summary
- remove hard-coded API endpoints in `index.html` and `dist/index.html`
- resolve API base from window variable, meta tag, or env var with relative-path default
- document how to override API base for different deployments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dcb819b4883219a16cdea5e81903c